### PR TITLE
Add keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "guid",
     "id",
     "objection",
-    "objectionjs"
+    "objectionjs",
+    "plugin",
+    "plugins"
   ],
   "license": "MIT",
   "author": {


### PR DESCRIPTION
This PR adds the `plugin` and `plugins` keywords to the `package.json`.