### PR TITLE
Add possibility to provide custom values

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = options => {
         const parent = super.$beforeInsert(context);
 
         return Promise.resolve(parent)
-          .then(() => options.generateGuid(context))
+          .then(() => this[options.field] || options.generateGuid(context))
           .then(guid => {
             this[options.field] = guid;
           });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -57,5 +57,32 @@ describe('GuidIdPlugin', () => {
         expect(model).toEqual({ foo: 'bar' });
       });
     });
+
+    it('should not update `id` property value and not call `generateGuid` if an `model.id` is already defined', () => {
+      const generateGuid = jest.fn();
+      const model = modelFactory({ generateGuid });
+      const parent = model.$beforeInsert();
+
+      model.id = 'foo';
+
+      return Promise.resolve(parent).then(() => {
+        expect(model).toEqual({ id: 'foo' });
+      });
+    });
+
+    it('should not update custom property value and not call `generateGuid` if an property value is already defined', () => {
+      const generateGuid = jest.fn();
+      const model = modelFactory({
+        field: 'foo',
+        generateGuid
+      });
+      const parent = model.$beforeInsert();
+
+      model.foo = 'bar';
+
+      return Promise.resolve(parent).then(() => {
+        expect(model).toEqual({ foo: 'bar' });
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR adds the possibility to provide custom values to the configured field.

If your model already has a value for the configured field, the value is not overwritten.
