### PR TITLE
Add prettier code formatter

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,14 +11,16 @@ const uuid = require('uuid');
  */
 
 module.exports = options => {
-  options = Object.assign({
-    field: 'id',
-    generateGuid: () => uuid.v4()
-  }, options);
+  options = Object.assign(
+    {
+      field: 'id',
+      generateGuid: () => uuid.v4()
+    },
+    options
+  );
 
   return Model => {
     return class extends Model {
-
       /**
        * Before insert.
        */
@@ -27,7 +29,10 @@ module.exports = options => {
         const parent = super.$beforeInsert(context);
 
         return Promise.resolve(parent)
-          .then(() => this[options.field] || options.generateGuid.call(this, context))
+          .then(
+            () =>
+              this[options.field] || options.generateGuid.call(this, context)
+          )
           .then(guid => {
             this[options.field] = guid;
           });

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "lint-staged": {
     "index.js": [
+      "prettier --single-quote --write",
       "eslint",
       "git add",
       "jest --findRelatedTests --forceExit"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "knex": "^0.13.0",
     "lint-staged": "^4.0.2",
     "objection": "^0.8.5",
-    "pre-commit": "^1.2.2"
+    "pre-commit": "^1.2.2",
+    "prettier": "^1.12.1"
   },
   "engines": {
     "node": ">=6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2329,6 +2329,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.1.tgz#c1ad20e803e7749faf905a409d2367e06bbe7325"
+
 pretty-format@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.3.tgz#020e350a560a1fe1a98dc3beb6ccffb386de8b14"


### PR DESCRIPTION
This adds Prettier to ensure that all PRs follow the same code formatting rules. This is done by running prettier command on lint-staged.

