### PR TITLE
Fix uuid to uuid/v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-const uuid = require('uuid');
+const uuid = require('uuid/v4');
 
 /**
  * Export `guid`.
@@ -14,7 +14,7 @@ module.exports = options => {
   options = Object.assign(
     {
       field: 'id',
-      generateGuid: () => uuid.v4()
+      generateGuid: () => uuid()
     },
     options
   );

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,7 @@
  * Jest mocks.
  */
 
-jest.mock('uuid', () => ({ v4: jest.fn(() => 'foobar') }));
+jest.mock('uuid/v4', () => jest.fn(() => 'foobar'));
 
 /**
  * Module dependencies.


### PR DESCRIPTION
uuid deprecated `require('uuid')` in favor of `require('uuid/v#')`